### PR TITLE
Fixed TargetErrors

### DIFF
--- a/python/data_structures/linked_list.py
+++ b/python/data_structures/linked_list.py
@@ -13,7 +13,6 @@ class LinkedList:
         while current is not None:
             text += "{ " + str(current.value) + " } -> "
             current = current.next
-
         return text + "NULL"
 
     def insert(self, val):
@@ -41,14 +40,13 @@ class LinkedList:
             self.head = new_node
             return f"Successfully created {new}!"
 
-        while current is not None:
+        while current and current.next is not None:
             if current.next.value == idx:
                 new_node = Node(new)
                 new_node.next = current.next
                 current.next = new_node
                 return f"Successfully created {new}!"
             current = current.next
-
         raise TargetError
 
     def insert_after(self, idx, new):
@@ -63,7 +61,7 @@ class LinkedList:
                 current.next = new_node
                 return f"Successfully created {new}!"
             current = current.next
-
+        raise TargetError
 
     def includes(self, val):
         current = self.head
@@ -71,7 +69,6 @@ class LinkedList:
             if current.value == val:
                 return True
             current = current.next
-
         return False
 
 class Node:

--- a/python/tests/code_challenges/test_linked_list_insertions.py
+++ b/python/tests/code_challenges/test_linked_list_insertions.py
@@ -53,7 +53,6 @@ def test_insert_before_empty():
     with pytest.raises(TargetError):
         linked_list.insert_before("radish", "zucchinni")
 
-@pytest.mark.skip("TODO")
 def test_insert_before_missing():
     linked_list = LinkedList()
 
@@ -70,7 +69,6 @@ def test_insert_after_empty():
         linked_list.insert_after("radish", "zucchinni")
 
 
-@pytest.mark.skip("TODO")
 def test_insert_after_missing():
     linked_list = LinkedList()
 


### PR DESCRIPTION
Raised TargetErrors at end of functions to handle a missing target value. Changed while loop condition in insert_before to avoid a situation where current.next is None. All tests are now passing.